### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/babel-helper-vue-transform-on/index.js
+++ b/packages/babel-helper-vue-transform-on/index.js
@@ -1,7 +1,7 @@
 const transformOn = (obj) => {
   const result = {};
   Object.keys(obj).forEach((evt) => {
-    result[`on${evt[0].toUpperCase()}${evt.substr(1)}`] = obj[evt];
+    result[`on${evt[0].toUpperCase()}${evt.slice(1)}`] = obj[evt];
   });
   return result;
 };


### PR DESCRIPTION
### 🤔 What is the nature of this change?

- [ ] New feature
- [ ] Fix bug
- [ ] Style optimization
- [ ] Code style optimization
- [ ] Performance optimization
- [ ] Build optimization
- [x] Refactor code or style
- [ ] Test related
- [ ] Other

### 🔗 Related Issue

<!--
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 Background or solution

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  No user side changes |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- From: https://github.com/one-template/pr-template -->
