### PR TITLE
fix: missing colon in event name for dynamic model arguments

### DIFF
--- a/packages/babel-plugin-jsx/src/transform-vue-jsx.ts
+++ b/packages/babel-plugin-jsx/src/transform-vue-jsx.ts
@@ -208,7 +208,7 @@ const buildProps = (path: NodePath<t.JSXElement>, state: State) => {
             }
 
             const updateName = isDynamic
-              ? t.binaryExpression('+', t.stringLiteral('onUpdate'), propName)
+              ? t.binaryExpression('+', t.stringLiteral('onUpdate:'), propName)
               : t.stringLiteral(
                   `onUpdate:${
                     (propName as t.StringLiteral)?.value || 'modelValue'

--- a/packages/babel-plugin-jsx/test/__snapshots__/snapshot.test.ts.snap
+++ b/packages/babel-plugin-jsx/test/__snapshots__/snapshot.test.ts.snap
@@ -269,7 +269,7 @@ const b = {
 };
 _createVNode(_Fragment, null, [_createVNode(_resolveComponent("A"), {
   [foo]: xx,
-  ["onUpdate" + foo]: $event => xx = $event
+  ["onUpdate:" + foo]: $event => xx = $event
 }, null, 16), _createVNode(_resolveComponent("B"), {
   "modelValue": xx,
   "modelModifiers": {
@@ -281,25 +281,25 @@ _createVNode(_Fragment, null, [_createVNode(_resolveComponent("A"), {
   [foo + "Modifiers"]: {
     "a": true
   },
-  ["onUpdate" + foo]: $event => xx = $event
+  ["onUpdate:" + foo]: $event => xx = $event
 }, null, 16), _createVNode(_resolveComponent("D"), {
   [foo === 'foo' ? 'a' : 'b']: xx,
   [(foo === 'foo' ? 'a' : 'b') + "Modifiers"]: {
     "a": true
   },
-  ["onUpdate" + (foo === 'foo' ? 'a' : 'b')]: $event => xx = $event
+  ["onUpdate:" + (foo === 'foo' ? 'a' : 'b')]: $event => xx = $event
 }, null, 16), _createVNode(_resolveComponent("E"), {
   [a()]: xx,
   [a() + "Modifiers"]: {
     "a": true
   },
-  ["onUpdate" + a()]: $event => xx = $event
+  ["onUpdate:" + a()]: $event => xx = $event
 }, null, 16), _createVNode(_resolveComponent("F"), {
   [b.c]: xx,
   [b.c + "Modifiers"]: {
     "a": true
   },
-  ["onUpdate" + b.c]: $event => xx = $event
+  ["onUpdate:" + b.c]: $event => xx = $event
 }, null, 16)]);"
 `;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->

### 🤔 What is the nature of this change?

- [ ] New feature
- [x] Fix bug
- [ ] Style optimization
- [ ] Code style optimization
- [ ] Performance optimization
- [ ] Build optimization
- [ ] Refactor code or style
- [ ] Test related
- [ ] Other

### 🔗 Related Issue

<!--
Describe the source of related requirements, such as the related issue discussion link.
-->

fixes #602
fixes #679

### 💡 Background or solution

<!--
The specific problem solved.
-->

https://vue-jsx-explorer.netlify.app/#const%20v%20%3D%20(%3C%3E%0A%20%20%3CMyComp%20v-model%3Atitle%3D%7B%20title.value%20%7D%3E%3C%2FMyComp%3E%0A%20%20%3CMyComp%20v-model%3D%7B%20%5Btitle.value%2C%20'title'%5D%7D%3E%3C%2FMyComp%3E%0A%20%20%3CMyComp%20v-model%3D%7B%20%5Btitle.value%2C%20key%5D%7D%3E%3C%2FMyComp%3E%0A%3C%2F%3E)%0A

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- From: https://github.com/one-template/pr-template -->
