### PR TITLE
fix: v-slots should not import resolveDirective

### DIFF
--- a/packages/babel-plugin-jsx/src/parseDirectives.ts
+++ b/packages/babel-plugin-jsx/src/parseDirectives.ts
@@ -81,7 +81,7 @@ const parseDirectives = (params: {
   }
 
   const shouldResolve =
-    !['html', 'text', 'model', 'models'].includes(directiveName) ||
+    !['html', 'text', 'model', 'slots', 'models'].includes(directiveName) ||
     (isVModel && !isComponent);
 
   let modifiers = directiveModifiers;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->

### 🤔 What is the nature of this change?

- [x] Fix bug

### 🔗 Related Issue

#697 
<!--
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 Background or solution

Add slots to unresolve whitelist

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- From: https://github.com/one-template/pr-template -->
