### PR TITLE
feat: add isGlobalElement option

### DIFF
--- a/packages/babel-plugin-jsx/README.md
+++ b/packages/babel-plugin-jsx/README.md
@@ -51,6 +51,14 @@ Default: `undefined`
 
 configuring custom elements
 
+#### isGlobalElement
+
+Type: `(tag: string) => boolean`
+
+Default: `undefined`
+
+configuring global elements so that they don't need to be wrapped by `resolveComponent`.
+
 #### mergeProps
 
 Type: `boolean`

--- a/packages/babel-plugin-jsx/src/interface.ts
+++ b/packages/babel-plugin-jsx/src/interface.ts
@@ -20,6 +20,8 @@ export interface VueJSXPluginOptions {
   mergeProps?: boolean;
   /** configuring custom elements */
   isCustomElement?: (tag: string) => boolean;
+  /** configuring global elements */
+  isGlobalElement?: (tag: string) => boolean;
   /** enable object slots syntax */
   enableObjectSlots?: boolean;
   /** Replace the function used when compiling JSX expressions */

--- a/packages/babel-plugin-jsx/src/utils.ts
+++ b/packages/babel-plugin-jsx/src/utils.ts
@@ -112,8 +112,8 @@ export const getTag = (
             : state.opts.isGlobalElement?.(name)
               ? t.identifier(name)
               : t.callExpression(createIdentifier(state, 'resolveComponent'), [
-                t.stringLiteral(name),
-              ]);
+                  t.stringLiteral(name),
+                ]);
     }
 
     return t.stringLiteral(name);

--- a/packages/babel-plugin-jsx/src/utils.ts
+++ b/packages/babel-plugin-jsx/src/utils.ts
@@ -109,7 +109,9 @@ export const getTag = (
           ? t.identifier(name)
           : state.opts.isCustomElement?.(name)
             ? t.stringLiteral(name)
-            : t.callExpression(createIdentifier(state, 'resolveComponent'), [
+            : state.opts.isGlobalElement?.(name)
+              ? t.identifier(name)
+              : t.callExpression(createIdentifier(state, 'resolveComponent'), [
                 t.stringLiteral(name),
               ]);
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->

### 🤔 What is the nature of this change?

- [x] New feature
- [ ] Fix bug
- [ ] Style optimization
- [ ] Code style optimization
- [ ] Performance optimization
- [ ] Build optimization
- [ ] Refactor code or style
- [ ] Test related
- [ ] Other

### 🔗 Related Issue

<!--
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 Background or solution

This option is a function to control whether to be wrapped by resolveComponent when the component is not defined.
So that unplugin-auto-import can correct collect `vue-jsx` component just like `@vitejs/plugin-react`.

<!--
The specific problem solved.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- From: https://github.com/one-template/pr-template -->
