### PR TITLE
fix: exclude TemplateLiteral expression from isConstant

### DIFF
--- a/packages/babel-plugin-jsx/src/utils.ts
+++ b/packages/babel-plugin-jsx/src/utils.ts
@@ -323,7 +323,7 @@ export const isConstant = (
       isConstant((property as any).value)
     );
   }
-  if (t.isLiteral(node)) {
+  if (t.isLiteral(node) && !t.isTemplateLiteral(node)) {
     return true;
   }
   return false;

--- a/packages/babel-plugin-jsx/src/utils.ts
+++ b/packages/babel-plugin-jsx/src/utils.ts
@@ -323,7 +323,9 @@ export const isConstant = (
       isConstant((property as any).value)
     );
   }
-  if (!t.isTemplateLiteral(node) && t.isLiteral(node)) {
+  if (
+    t.isTemplateLiteral(node) ? !node.expressions.length : t.isLiteral(node)
+  ) {
     return true;
   }
   return false;

--- a/packages/babel-plugin-jsx/src/utils.ts
+++ b/packages/babel-plugin-jsx/src/utils.ts
@@ -323,7 +323,7 @@ export const isConstant = (
       isConstant((property as any).value)
     );
   }
-  if (t.isLiteral(node) && !t.isTemplateLiteral(node)) {
+  if (!t.isTemplateLiteral(node) && t.isLiteral(node)) {
     return true;
   }
   return false;

--- a/packages/babel-plugin-jsx/test/__snapshots__/snapshot.test.ts.snap
+++ b/packages/babel-plugin-jsx/test/__snapshots__/snapshot.test.ts.snap
@@ -23,6 +23,14 @@ _createVNode("div", {
 }, null, 6);"
 `;
 
+exports[`TemplateLiteral prop and event co-usage > TemplateLiteral prop and event co-usage 1`] = `
+"import { createVNode as _createVNode } from "vue";
+_createVNode("div", {
+  "value": \`\${foo}\`,
+  "onClick": () => foo.value++
+}, null, 8, ["value", "onClick"]);"
+`;
+
 exports[`Without JSX should work > Without JSX should work 1`] = `
 "import { createVNode } from 'vue';
 createVNode('div', null, ['Without JSX should work']);"

--- a/packages/babel-plugin-jsx/test/snapshot.test.ts
+++ b/packages/babel-plugin-jsx/test/snapshot.test.ts
@@ -208,6 +208,10 @@ const transpile = (source: string, options: VueJSXPluginOptions = {}) =>
     name: 'using v-slots without children should not be spread',
     from: '<A v-slots={slots} />',
   },
+  {
+    name: 'TemplateLiteral prop and event co-usage',
+    from: '<div value={`${foo}`} onClick={() => foo.value++}></div>',
+  },
 ].forEach(({ name, from }) => {
   test(name, async () => {
     expect(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->

### 🤔 What is the nature of this change?

- [ ] New feature
- [x] Fix bug
- [ ] Style optimization
- [ ] Code style optimization
- [ ] Performance optimization
- [ ] Build optimization
- [ ] Refactor code or style
- [ ] Test related
- [ ] Other

### 🔗 Related Issue

closed #728

<!--
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 Background or solution

<!--
The specific problem solved.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- From: https://github.com/one-template/pr-template -->
