### PR TITLE
Support SVG 2 elements, using @vue/shared to ensure consistent behavi…

### DIFF
--- a/packages/babel-plugin-jsx/package.json
+++ b/packages/babel-plugin-jsx/package.json
@@ -31,15 +31,13 @@
     "@babel/types": "^7.26.9",
     "@vue/babel-helper-vue-transform-on": "workspace:*",
     "@vue/babel-plugin-resolve-type": "workspace:*",
-    "html-tags": "^3.3.1",
-    "svg-tags": "^1.0.0"
+    "@vue/shared": "^3.5.13"
   },
   "devDependencies": {
     "@babel/core": "^7.26.9",
     "@babel/preset-env": "^7.26.9",
     "@types/babel__template": "^7.4.4",
     "@types/babel__traverse": "^7.20.6",
-    "@types/svg-tags": "^1.0.2",
     "@vue/test-utils": "^2.4.6",
     "regenerator-runtime": "^0.14.1",
     "vue": "catalog:"

--- a/packages/babel-plugin-jsx/src/utils.ts
+++ b/packages/babel-plugin-jsx/src/utils.ts
@@ -1,8 +1,8 @@
 import * as t from '@babel/types';
 import { type NodePath } from '@babel/traverse';
+import { isHTMLTag , isSVGTag } from '@vue/shared'
 import type { State } from './interface';
 import SlotFlags from './slotFlags';
-import { isHTMLTag , isSVGTag } from '@vue/shared'
 export const JSX_HELPER_KEY = 'JSX_HELPER_KEY';
 export const FRAGMENT = 'Fragment';
 export const KEEP_ALIVE = 'KeepAlive';

--- a/packages/babel-plugin-jsx/src/utils.ts
+++ b/packages/babel-plugin-jsx/src/utils.ts
@@ -1,6 +1,6 @@
 import * as t from '@babel/types';
 import { type NodePath } from '@babel/traverse';
-import { isHTMLTag , isSVGTag } from '@vue/shared'
+import { isHTMLTag, isSVGTag } from '@vue/shared';
 import type { State } from './interface';
 import SlotFlags from './slotFlags';
 export const JSX_HELPER_KEY = 'JSX_HELPER_KEY';
@@ -97,10 +97,7 @@ export const getTag = (
   const namePath = path.get('openingElement').get('name');
   if (namePath.isJSXIdentifier()) {
     const { name } = namePath.node;
-    if (
-      !isHTMLTag(name) &&
-      !isSVGTag(name)
-    ) {
+    if (!isHTMLTag(name) && !isSVGTag(name)) {
       return name === FRAGMENT
         ? createIdentifier(state, FRAGMENT)
         : path.scope.hasBinding(name)

--- a/packages/babel-plugin-jsx/src/utils.ts
+++ b/packages/babel-plugin-jsx/src/utils.ts
@@ -1,10 +1,8 @@
 import * as t from '@babel/types';
-import htmlTags from 'html-tags';
-import svgTags from 'svg-tags';
 import { type NodePath } from '@babel/traverse';
 import type { State } from './interface';
 import SlotFlags from './slotFlags';
-
+import { isHTMLTag , isSVGTag } from '@vue/shared'
 export const JSX_HELPER_KEY = 'JSX_HELPER_KEY';
 export const FRAGMENT = 'Fragment';
 export const KEEP_ALIVE = 'KeepAlive';
@@ -60,8 +58,8 @@ export const checkIsComponent = (
   return (
     !state.opts.isCustomElement?.(tag) &&
     shouldTransformedToSlots(tag) &&
-    !htmlTags.includes(tag as htmlTags.htmlTags) &&
-    !svgTags.includes(tag)
+    !isHTMLTag(tag) &&
+    !isSVGTag(tag)
   );
 };
 
@@ -100,8 +98,8 @@ export const getTag = (
   if (namePath.isJSXIdentifier()) {
     const { name } = namePath.node;
     if (
-      !htmlTags.includes(name as htmlTags.htmlTags) &&
-      !svgTags.includes(name)
+      !isHTMLTag(name) &&
+      !isSVGTag(name)
     ) {
       return name === FRAGMENT
         ? createIdentifier(state, FRAGMENT)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,12 +106,9 @@ importers:
       '@vue/babel-plugin-resolve-type':
         specifier: workspace:*
         version: link:../babel-plugin-resolve-type
-      html-tags:
-        specifier: ^3.3.1
-        version: 3.3.1
-      svg-tags:
-        specifier: ^1.0.0
-        version: 1.0.0
+      '@vue/shared':
+        specifier: ^3.5.13
+        version: 3.5.13
     devDependencies:
       '@babel/core':
         specifier: ^7.26.9
@@ -125,9 +122,6 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.20.6
         version: 7.20.6
-      '@types/svg-tags':
-        specifier: ^1.0.2
-        version: 1.0.2
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
@@ -1256,9 +1250,6 @@ packages:
 
   '@types/node@22.13.4':
     resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
-
-  '@types/svg-tags@1.0.2':
-    resolution: {integrity: sha512-D8rhCFfpmWzXvzVqdXo40EXNeropfqp4gvwn8fcVfzYIci8M1C1tk/L26Yacn/U9vaPM7FlS73BNoUtfjAjwAw==}
 
   '@typescript-eslint/eslint-plugin@8.24.1':
     resolution: {integrity: sha512-ll1StnKtBigWIGqvYDVuDmXJHVH4zLVot1yQ4fJtLpL7qacwkxJc1T0bptqw+miBQ/QfUbhl1TcQ4accW5KUyA==}
@@ -4048,8 +4039,6 @@ snapshots:
   '@types/node@22.13.4':
     dependencies:
       undici-types: 6.20.0
-
-  '@types/svg-tags@1.0.2': {}
 
   '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3))(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
### 🤔 What is the nature of this change?

- [ ] New feature
- [x] Fix bug
- [ ] Style optimization
- [ ] Code style optimization
- [ ] Performance optimization
- [ ] Build optimization
- [ ] Refactor code or style
- [ ] Test related
- [ ] Other

### 🔗 Related Issue ：jsx behavior not consistent with vue template

Note the call to `_resolveComponent` in the

[Vue SFC Playground - Example template](https://play.vuejs.org/#eNqNU8tu2zAQ/JWFLnEAV1Lt1gdDCdA0Btoe2qLpURdFXElMKS5BUo/C8L93KTtKigRGBB12Z4bc0ZDaR5+MifsOo22UudJK48Gh7wyoQtdXeeRdHl3nOkuOJJfceGyNKjxyB5C5voZSFc6xvLh3pDqPeQSDFL5haLVJuWtQ1o2f2hW3vcThhkbuU0hhnW7giFdSKQY16bDF2Coddm28N9skGYYhHtYx2TpZpWma8ODJHPCTCazcqeaO9/Fo5z4geGvJ3DWFoAFEmLzhCeIvF++5cF7cYi8LL0mfoEoRiXclKbKM2Pq+WKRLOL3xx0uWJE8Tk/9GZsnsh6Pr6ynCZ7FFS062JF3JOn5wpDn+fRDnUUmtkQrtDxOscPpbmJjAFUrR8G3CvO1w+YiXDZZ/XsEf3BiwPPpp0aHtOdOZ84Wt0R/p3d13HLmeyZZEp1h9hvyF00mzx6PsptOCbT/TTW6/toasl7r+7XajR+0ePyoYDcrDpM8jvoOfz3z6k911/GFal+sDpxjWvOH+yskG7MFiBQeoLLVwwcsuwn3mc3AeKio7hwKugmZRFcrhZWD5IKXG3WjI4WI/yw5MnvsrzPUX5ABgIKtElpgXN+DwD/UuISc=) 

[Vue SFC Playground -  Example jsx](https://play.vuejs.org/#eNqFUlGP0zAM/itWX26TRtvbYA9TN4njJgEPgLh7rIR6jdvmSJMoSdeiaf8dJ+3GJNCQ8mB//mx/sX2M3msdHzqMNlFmS8O1A4uu0yAKWW/zyNkhj3a5LJW0Dp7Ruh/3sIXZHLY7mGX2UEMpCmuJWrxYJTqHeQQ9Z64haLlOyWuQ140L7pLcA8f+QQ3kp5DCKl3DiFdcCAKlkr7E0ArpqzbO6U2S9H0f96tYmTpZpmmaUOOgCyBjWNlgkU01HJrJ8z4+GqWfmoKpHpjvuaba7BcZ92RYxx7xwAvHlZygSijF3pRKKEOIqV+KWbqA6cXv5kRJzt2Sq3ZZMunIvLbdPBhhoISR47DVonA4kqdB+kpZchWKFjRxmnXF6/jVKklrOfqEPCpVq7lA81V7sTaPNhAiPlYIofrPAXOmw8UZLxssf/4Df/VL3ZDxzaBFc6B5X2KuMDW6Mbx/+oID2Zdgq1gniH0j+B3DFZDGkfbQSUayr3hB7adWK+O4rJ/tfnAo7flTXqhnngI/j+g2P9z4+h+5q/htyMvliaboc27fdTgfHmTAEQxWcILKqBbuKO3O72y8+UqVnUVGR0+cWVUIi7TcXNK6ucT9oJXF2fFCO/1n83r3EWkA0CsjWJbovy7g9Bs0fCoz) 

### 💡 Background or solution

I encountered the following warning during development, I found that it was due to the old svg-tags library (someone mentioned pr for svg 2 support to the repository but it wasn't accepted yet), I changed the code to be consistent with the behavior of vue to solve the problem. 

```log
[Vue warn]: Failed to resolve component: feDropShadow
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement.
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     svg and html elements to use @vue/shared.       |
| 🇨🇳 Chinese |    svg 和 html 元素的判断改为使用 @vue/shared       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

