### PR TITLE
fix: resolve directives in nested scopes

### DIFF
--- a/packages/babel-plugin-jsx/README.md
+++ b/packages/babel-plugin-jsx/README.md
@@ -243,24 +243,29 @@ h(A, {
 
 #### custom directive
 
-Recommended when using string arguments
-
 ```jsx
 const App = {
-  directives: { custom: customDirective },
+  directives: { custom: vCustom },
   setup() {
-    return () => <a v-custom:arg={val} />;
+    return () => <a v-custom={val} />;
   },
 };
 ```
 
+Directive names will resolve a variable matching `/v[A-Z]/` first, `options.directives` is only needed to prevent the import from being reported as unused.
+
+Arguments and modifiers can be added as an array:
+
 ```jsx
-const App = {
-  directives: { custom: customDirective },
-  setup() {
-    return () => <a v-custom={[val, 'arg', ['a', 'b']]} />;
-  },
-};
+// same as v-custom:arg.a.b="val" in a .vue file
+<a v-custom={[val, 'arg', ['a', 'b']]} />
+```
+
+Or arguments as part of the attribute name:
+
+```jsx
+<a v-custom:arg={val} />
+<b v-custom:arg={[val, ['a', 'b']]} />
 ```
 
 ### Slot

--- a/packages/babel-plugin-jsx/src/parseDirectives.ts
+++ b/packages/babel-plugin-jsx/src/parseDirectives.ts
@@ -186,9 +186,13 @@ const resolveDirective = (
   }
   const referenceName =
     'v' + directiveName[0].toUpperCase() + directiveName.slice(1);
-  if (path.scope.references[referenceName]) {
-    return t.identifier(referenceName);
-  }
+  let scope = path.scope
+  do {
+    if (scope.references[referenceName]) {
+      return t.identifier(referenceName);
+    }
+    scope = scope.parent
+  } while (scope)
   return t.callExpression(createIdentifier(state, 'resolveDirective'), [
     t.stringLiteral(directiveName),
   ]);

--- a/packages/babel-plugin-jsx/test/__snapshots__/snapshot.test.ts.snap
+++ b/packages/babel-plugin-jsx/test/__snapshots__/snapshot.test.ts.snap
@@ -63,6 +63,12 @@ _createVNode(_Fragment, null, [_withDirectives(_createVNode(_resolveComponent("A
 }]])]);"
 `;
 
+exports[`directive in outer scope > directive in outer scope 1`] = `
+"import { resolveComponent as _resolveComponent, createVNode as _createVNode, withDirectives as _withDirectives } from "vue";
+const vXxx = {};
+() => _withDirectives(_createVNode(_resolveComponent("A"), null, null, 512), [[vXxx]]);"
+`;
+
 exports[`directive in scope > directive in scope 1`] = `
 "import { resolveComponent as _resolveComponent, createVNode as _createVNode, withDirectives as _withDirectives } from "vue";
 const vXxx = {};

--- a/packages/babel-plugin-jsx/test/snapshot.test.ts
+++ b/packages/babel-plugin-jsx/test/snapshot.test.ts
@@ -163,6 +163,15 @@ const transpile = (source: string, options: VueJSXPluginOptions = {}) =>
     `,
   },
   {
+    name: 'directive in outer scope',
+    from: `
+      const vXxx = {};
+      () => (
+        <A v-xxx />
+      );
+    `,
+  },
+  {
     name: 'vModels',
     from: '<C v-models={[[foo, ["modifier"]], [bar, "bar", ["modifier1", "modifier2"]]]} />',
   },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->

### 🤔 What is the nature of this change?

- [ ] New feature
- [x] Fix bug
- [ ] Style optimization
- [ ] Code style optimization
- [ ] Performance optimization
- [ ] Build optimization
- [ ] Refactor code or style
- [ ] Test related
- [ ] Other

### 💡 Background or solution

directives in slots were still using resolveDirective

```jsx
import vFoo

// withDirectives(..., [[vFoo]])
<A v-foo>
  {{
    default: () => (
      // withDirectives(..., [[resolveDirective('foo')]])
      <B v-foo />
    )
  }}
</A>
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

<!-- From: https://github.com/one-template/pr-template -->
