### PR TITLE
fix: resolve type reference in props annotation

### DIFF
--- a/packages/babel-plugin-resolve-type/src/index.ts
+++ b/packages/babel-plugin-resolve-type/src/index.ts
@@ -163,13 +163,21 @@ const plugin: (
         if (generics) {
           ctx!.propsTypeDecl = resolveTypeReference(generics)
         } else {
-          ctx!.propsTypeDecl = getTypeAnnotation(props.left)
+          const typeAnnotation = getTypeAnnotation(props.left)
+          ctx!.propsTypeDecl =
+            typeAnnotation && t.isTSTypeReference(typeAnnotation)
+              ? resolveTypeReference(typeAnnotation) || typeAnnotation
+              : typeAnnotation
         }
         ctx!.propsRuntimeDefaults = props.right
       } else if (generics) {
         ctx!.propsTypeDecl = resolveTypeReference(generics)
       } else {
-        ctx!.propsTypeDecl = getTypeAnnotation(props)
+        const typeAnnotation = getTypeAnnotation(props)
+        ctx!.propsTypeDecl =
+          typeAnnotation && t.isTSTypeReference(typeAnnotation)
+            ? resolveTypeReference(typeAnnotation) || typeAnnotation
+            : typeAnnotation
       }
 
       if (!ctx!.propsTypeDecl) return

--- a/packages/babel-plugin-resolve-type/test/__snapshots__/resolve-type.test.tsx.snap
+++ b/packages/babel-plugin-resolve-type/test/__snapshots__/resolve-type.test.tsx.snap
@@ -211,6 +211,26 @@ defineComponent<Props>((props = {
 });"
 `;
 
+exports[`resolve type > runtime props > with type reference annotation 1`] = `
+"import { defineComponent } from 'vue';
+interface MyProps {
+  list?: Array<{
+    id: number;
+    title: string;
+  }>;
+}
+defineComponent((props: MyProps) => {
+  return () => <div>{props.list?.length}</div>;
+}, {
+  props: {
+    list: {
+      type: Array,
+      required: false
+    }
+  }
+});"
+`;
+
 exports[`resolve type > w/ tsx 1`] = `
 "import { type SetupContext, defineComponent } from 'vue';
 defineComponent(() => {

--- a/packages/babel-plugin-resolve-type/test/resolve-type.test.tsx
+++ b/packages/babel-plugin-resolve-type/test/resolve-type.test.tsx
@@ -88,6 +88,24 @@ describe('resolve type', () => {
       )
       expect(result).toMatchSnapshot()
     })
+
+    test('with type reference annotation', async () => {
+      const result = await transform(
+        `
+        import { defineComponent } from 'vue';
+        interface MyProps {
+          list?: Array<{
+            id: number
+            title: string
+          }>
+        }
+        defineComponent((props: MyProps) => {
+          return () => <div>{props.list?.length}</div>;
+        })
+        `,
+      )
+      expect(result).toMatchSnapshot()
+    })
   })
 
   describe('runtime emits', () => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->

### 🤔 What is the nature of this change?

- [ ] New feature
- [x] Fix bug
- [ ] Style optimization
- [ ] Code style optimization
- [ ] Performance optimization
- [ ] Build optimization
- [ ] Refactor code or style
- [ ] Test related
- [ ] Other

### 🔗 Related Issue

<!--
Describe the source of related requirements, such as the related issue discussion link.
-->

### 💡 Background or solution

<!--
The specific problem solved.
-->

When the `resolveType` option is enabled in vue-jsx, props types cannot be inferred.
Reproduction link：[https://stackblitz.com/edit/vitejs-vite-hjex3faa?file=src%2FApp.tsx](https://stackblitz.com/edit/vitejs-vite-hjex3faa?file=src%2FApp.tsx)

<img width="580" height="283" alt="image" src="https://github.com/user-attachments/assets/4587a6a0-8181-4d07-a695-db6470e30af9" />

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     resolve type reference in props annotation      |
| 🇨🇳 Chinese |      为 props 增加引用类型声明解析     |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- From: https://github.com/one-template/pr-template -->
